### PR TITLE
Fixes for cross platform compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,131 @@
+## ==============================================================================
+##
+##  CMake project settings
+##
+## ==============================================================================
+
+## Name of the project handled by CMake
+project (HPCE-2014-CW4)
+
+## Minimum required version of CMake to configure the project
+cmake_minimum_required (VERSION 2.8)
+
+## Enforced CMake policy
+cmake_policy (VERSION 2.8)
+
+
+## ==============================================================================
+##
+##  Configure Khronos OpenCL Libs
+##
+## ==============================================================================
+
+set(OPENCL_SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/opencl_sdk/)
+
+set(OPENCL_SDK_HEADERS ${OPENCL_SDK_DIR}/include/)
+
+if(WIN32)
+  set(OPENCL_SDK_LIB     ${OPENCL_SDK_DIR}/lib/windows/x86/OpenCL.lib)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(OPENCL_SDK_LIB      ${OPENCL_SDK_DIR}/lib/windows/x86_64/OpenCL.lib)
+  endif()
+elseif(UNIX) 
+  set(OPENCL_SDK_LIB      ${OPENCL_SDK_DIR}/lib/cygwin/x86/libOpenCL.a)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(OPENCL_SDK_LIB      ${OPENCL_SDK_DIR}/lib/cygwin/x86_64/libOpenCL.a)
+  endif()
+else()
+  MESSAGE(FATAL_ERROR "ERROR: Unkown platform for OpenCL SDK")
+endif()
+
+
+## ==============================================================================
+##
+##  Configure Default Coursework Files
+##
+## ==============================================================================
+
+set(COURSEWORK_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/)
+
+set(HEAT_HPP ${CMAKE_CURRENT_SOURCE_DIR}/include/heat.hpp)
+set(HEAT_CPP ${CMAKE_CURRENT_SOURCE_DIR}/src/heat.cpp)
+
+include_directories(${COURSEWORK_HEADER} ${OPENCL_SDK_HEADERS})
+
+add_executable(test_opencl   ${HEAT_HPP}  ${HEAT_CPP}  ${CMAKE_CURRENT_SOURCE_DIR}/src/test_opencl.cpp)
+add_executable(make_world    ${HEAT_HPP}  ${HEAT_CPP}  ${CMAKE_CURRENT_SOURCE_DIR}/src/make_world.cpp)
+add_executable(render_world  ${HEAT_HPP}  ${HEAT_CPP}  ${CMAKE_CURRENT_SOURCE_DIR}/src/render_world.cpp)
+add_executable(step_world    ${HEAT_HPP}  ${HEAT_CPP}  ${CMAKE_CURRENT_SOURCE_DIR}/src/step_world.cpp)
+
+if(APPLE)
+  FIND_LIBRARY(OPENCL_LIBRARY OpenCL DOC "OpenCL lib for OSX")
+  target_link_libraries(test_opencl ${OPENCL_LIBRARY})
+  target_link_libraries(make_world ${OPENCL_LIBRARY})
+  target_link_libraries(render_world ${OPENCL_LIBRARY})
+  target_link_libraries(step_world ${OPENCL_LIBRARY})
+else()
+  target_link_libraries(test_opencl ${OPENCL_SDK_LIB})
+  target_link_libraries(make_world ${OPENCL_SDK_LIB})
+  target_link_libraries(render_world ${OPENCL_SDK_LIB})
+  target_link_libraries(step_world ${OPENCL_SDK_LIB})
+endif()
+
+
+## ==============================================================================
+##
+##  Configure Additional Coursework Files
+##
+## ==============================================================================
+
+## TODO : Change this param to your IC username
+set(LOGIN_ID "<your_login>") 
+
+set(USR_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/${LOGIN_ID})
+file(GLOB USR_SRC RELATIVE ${USR_SRC_DIR} ${USR_SRC_DIR}/*.cpp)
+
+foreach(SRC_FILE ${USR_SRC})
+  string(REPLACE ".cpp" "" EXECUTABLE ${SRC_FILE})
+  add_executable(${EXECUTABLE} ${HEAT_HPP} ${HEAT_CPP} ${USR_SRC_DIR}/${SRC_FILE})
+  if(APPLE)
+    target_link_libraries(${EXECUTABLE} ${OPENCL_LIBRARY})
+  else()
+    target_link_libraries(${EXECUTABLE} ${OPENCL_SDK_LIB})
+  endif()
+endforeach(SRC_FILE ${USR_SRC})
+
+
+## ==============================================================================
+##
+##  Compiler Flags
+##
+## ==============================================================================
+
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-Wall -std=c++11 -o2")
+
+
+## ==============================================================================
+##
+##  Configuration summary
+##
+## ==============================================================================
+
+message (STATUS "------------------------------------------------------------"  )
+message (STATUS "[HPCE-2014-CW4] Configuration summary."                        )
+message (STATUS "------------------------------------------------------------"  )
+message (STATUS " System configuration:"                                        )
+message (STATUS " .. Processor type ............. = ${CMAKE_SYSTEM_PROCESSOR}"  )
+message (STATUS " .. CMake executable ........... = ${CMAKE_COMMAND}"           )
+message (STATUS " .. CMake version .............. = ${CMAKE_VERSION}"           )
+message (STATUS " .. System name ................ = ${CMAKE_SYSTEM}"            )
+message (STATUS " .. C++ compiler ............... = ${CMAKE_CXX_COMPILER}"      )
+message (STATUS " .. C compiler ................. = ${CMAKE_C_COMPILER}"        )
+message (STATUS " .. size(void*) ................ = ${CMAKE_SIZEOF_VOID_P}"     )
+
+IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/${LOGIN_ID})
+  message (STATUS " Additional Coursework Files:")
+  foreach( SRC_FILE ${USR_SRC} )
+    message (STATUS " .. ${SRC_FILE}")
+  endforeach( SRC_FILE ${USR_SRC} )
+endif()
+
+message (STATUS "------------------------------------------------------------"  )

--- a/cmake_setup.md
+++ b/cmake_setup.md
@@ -1,0 +1,48 @@
+CMake
+================================
+
+This readme will guide you how to setup the project using CMake. CMake generates native makefiles and IDE workspaces that can be used in an environment of your choice.
+
+Building the Project
+--
+
+### CMake GUI (Windows and Mac)
+1. [Download](http://www.cmake.org/download/), install and launch CMake
+2. For `Where is the source code:`, specify the location for `../path/to/hpce-2014-cw4`
+3. For `Where to build the binaries:`, specify a location where the project files will be created in i.e. `../path/to/hpce-2014-cw4/bin`
+4. Click Configure (if the `bin` folder does not exist, CMake may ask to create one)
+5. CMake will now ask to `Specify the generator for this project`. Mac users here should select `Xcode`, Windows users should select (the installed version of) `Visual Studio`
+6. Click Done
+7. Click Configure and then Generate
+8. If all correct, there should be no red.
+
+Inside the `bin` folder there will now be a Xcode Project file `HPCE-2014-CW4.xcodeproj` (if on mac) or a Visual Studio Solution `HPCE-2014-CW4.sln` (if on Windows). Double click this to launch the IDE. 
+
+The IDE will have all the executibles/binaries listed as independent projects.
+If `ALL_BUILD` is selected, pressing build on the IDE will build all executibles/binaries.
+If a particular executible/binary is selected, pressing build will build only that executible/binary.
+The built executables/binaries should be in `bin/Debug`.
+
+### CMake Command Line (Linux/MinGW/Cygwin/Mac Terminal)
+`cmake` is required via the command line, linux users can `sudo apt-get install cmake`. 
+Not 100% sure if already available on MinGW and Cygwin. Mac users can install cmake into the command line through the CMake app. 
+
+First, `cd` into the `hpce-2014-cw4` folder, then run:
+
+1. `mkdir bin`
+2. `cd bin`
+3. `cmake ..`
+4. `make`
+
+The binaries will be built in the `bin` folder. Note: for MinGW/Cygwin users, if Visual Studio is installed, CMake may default into generating Visual Studio project file.
+
+Adding additional coursework files 
+--
+Throughout the coursework, you will be adding files into `src/your_login`. You need to rerun CMake so that they are added to the project.
+
+1. Set your `your_login` in `CMakeLists.txt` (around line 80)
+2. Add your .cpp files into `src/your_login`
+3. rerun CMake (above) to regenerate makefiles or update changes in IDEs
+
+CMakeLists.txt will look in `src/your_login` for `.cpp` files, where it will link the `.cpp` file with appropriate libraries and create an binary/executable. If working with an IDE, this will show up as a new project. 
+

--- a/include/heat.hpp
+++ b/include/heat.hpp
@@ -9,6 +9,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstdint>
+#include <algorithm>
+#include <string>
 
 namespace hpce{
 	

--- a/src/test_opencl.cpp
+++ b/src/test_opencl.cpp
@@ -11,8 +11,9 @@
 
 // Update: this doesn't work in windows - if necessary take it out. It is in
 // here because some unix platforms complained if it wasn't heere.
-# include <alloca.h>
-
+#ifndef WIN32
+#include <alloca.h>
+#endif
 
 // Update: Work around deprecation warnings
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS 


### PR DESCRIPTION
1. added #ifndef preprocessor directives to disable #include < alloca.h >
   if the platform is Windows
2. added ‘#include < algorithm >’ to fix C2039 error in Visual Studio
3. added ‘#include < string >’ to fix C2679 error in Visual Studio
4. added CMakeLists.txt to generate makefiles and/or project files for
   cross platform building
5. added cmake_setup.md, readme for setting up the project using CMake
